### PR TITLE
improvements

### DIFF
--- a/VideoStream.php
+++ b/VideoStream.php
@@ -11,27 +11,6 @@ class VideoStream
     private $pass = 'password';
     private $buffersize = 1024 * 1024;
 
-    /**  This method is called whenever a new chunk of data arrived from cURL.  */
-    public function callback($curl, $data)
-    {
-        ob_get_clean();
-        if (($data === false) || ($data == null))
-        {
-            throw new \Exception (curl_error($curl) . " " . curl_errno($curl));
-        }
-        $length = strlen($data);
-        header("Content-type: video/mp4"); //watched out for your video format!
-        header("Transfer-encoding: chunked");
-        header("Connection: keep-alive");
-        header("Cache-Control: max-age=2592000, public");
-        header("Expires: ".gmdate('D, d M Y H:i:s', time()+2592000) . ' GMT');
-        header("Last-Modified: ".gmdate('D, d M Y H:i:s', @filemtime($this->url)) . ' GMT' );
-        echo $data;
-        ob_flush();
-        flush();
-        return $length;
-    }
-
     /**  Key function for streaming */
     public function getStream($url)
     {
@@ -41,10 +20,15 @@ class VideoStream
                 CURLOPT_HEADER => 0,
                 CURLOPT_USERPWD => "$this->login:$this->pass", //if your server requires authorisation
                 CURLOPT_FOLLOWLOCATION => 1,
-                CURLOPT_BUFFERSIZE => $this->buffersize,
-                CURLOPT_WRITEFUNCTION => array($this, "callback")
+                CURLOPT_BUFFERSIZE => $this->buffersize
             )
         );
+        header("Content-type: video/mp4"); //watched out for your video format!
+        header("Transfer-encoding: chunked");
+        header("Connection: keep-alive");
+        header("Cache-Control: max-age=2592000, public");
+        header("Expires: ".gmdate('D, d M Y H:i:s', time()+2592000) . ' GMT');
+        header("Last-Modified: ".gmdate('D, d M Y H:i:s', @filemtime($this->url)) . ' GMT' );
         curl_exec($curl);
         curl_close($curl);
     }


### PR DESCRIPTION
1: the original code was trying to re-send headers for each chunk of the video, this will only work the first time! for every subsequent chunk, no headers are sent, but you get this error in your php error log ***for every chunk***: ```Warning: Cannot modify header information - headers already sent by (output started at /some/file.php:12) in /some/file.php on line 123```,  so i changed that to only send the headers once. (did you ever check your php error log after running the original code? )

2: i removed the custom CURLOPT_WRITEFUNCTION callback, the default writer already outputs the data directly to the browser anyway, and the C-implemented default write-function use less CPU than using a php-implemented callback, there's no good reason to use a custom callback here.